### PR TITLE
미디어와 피드 페이지 오류 해결

### DIFF
--- a/frontend/src/routes/community/feed/+page.server.ts
+++ b/frontend/src/routes/community/feed/+page.server.ts
@@ -11,18 +11,21 @@ export const load: PageServerLoad = async ({ url }) => {
     const totalPages = Math.ceil(allPosts.length / POSTS_PER_PAGE);
 
     if (Number(pageParam) != currentPage) {
-        url.searchParams.set("page", currentPage);
-        throw redirect(307, url.toString());
+        const newUrl = new URL(url);
+        newUrl.searchParams.set("page", currentPage.toString());
+        throw redirect(307, newUrl.toString());
     }
 
     if (currentPage < 1) {
-        url.searchParams.set("page", "1");
-        throw redirect(307, url.toString());
+        const newUrl = new URL(url);
+        newUrl.searchParams.set("page", "1");
+        throw redirect(307, newUrl.toString());
     } else if (currentPage > totalPages) {
-        url.searchParams.set("page", totalPages.toString());
-        throw redirect(307, url.toString());
+        const newUrl = new URL(url);
+        newUrl.searchParams.set("page", totalPages.toString());
+        throw redirect(307, newUrl.toString());
     }
-    
+
     const offset = (currentPage - 1) * POSTS_PER_PAGE;
     const slicedPostSummary: PostSummary[] = allPosts.slice(
         offset,

--- a/frontend/src/routes/community/media/+page.server.ts
+++ b/frontend/src/routes/community/media/+page.server.ts
@@ -11,18 +11,21 @@ export const load: PageServerLoad = async ({ url }) => {
     const totalPages = Math.ceil(allMedia.length / POSTS_PER_PAGE);
 
     if (Number(pageParam) != currentPage) {
-        url.searchParams.set("page", currentPage);
-        throw redirect(307, url.toString());
+        const newUrl = new URL(url);
+        newUrl.searchParams.set("page", currentPage.toString());
+        throw redirect(307, newUrl.toString());
     }
 
     if (currentPage < 1) {
-        url.searchParams.set("page", "1");
-        throw redirect(307, url.toString());
+        const newUrl = new URL(url);
+        newUrl.searchParams.set("page", "1");
+        throw redirect(307, newUrl.toString());
     } else if (currentPage > totalPages) {
-        url.searchParams.set("page", totalPages.toString());
-        throw redirect(307, url.toString());
+        const newUrl = new URL(url);
+        newUrl.searchParams.set("page", totalPages.toString());
+        throw redirect(307, newUrl.toString());
     }
-    
+
     const offset = (currentPage - 1) * POSTS_PER_PAGE;
     const slicedMediaSummary: MediaSummary[] = allMedia.slice(
         offset,


### PR DESCRIPTION
이전에는 500 오류 페이지 밖에 보이지 않았던 미디어와 피드 페이지의 오류를 해결함.

/community/feed/+page.server.ts와 /community/media/+page.server.ts 모두 url.searchParams 속성에 직접 접근하려고 함.

  Before (causing 500 error):
  url.searchParams.set("page", currentPage);

  After (fixed):
  const newUrl = new URL(url);
  newUrl.searchParams.set("page", currentPage.toString());