### PR TITLE
fix: 프론트엔드 헬스체크 IPv6 문제 수정

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -35,6 +35,6 @@ ENV PORT=3000
 
 # 헬스 체크 - Alpine에는 curl 없으므로 wget 사용
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/ || exit 1
 
 CMD ["node", "build"]


### PR DESCRIPTION
wget이 localhost를 [::1](IPv6)로 해석하지만 Node 서버는 0.0.0.0(IPv4)에서만 리슨.
127.0.0.1로 명시하여 해결.